### PR TITLE
Update deck.py to account for sequencing

### DIFF
--- a/Engine/deck.py
+++ b/Engine/deck.py
@@ -4,11 +4,49 @@ import random
 class Deck:
     SUITS = ["Spades", "Clubs", "Diamonds", "Hearts"]
 
-    def __init__(self):
+    def init(self, shuffleFlag = True, deckSequence = None):
         self.cards = []
-        for suit in self.SUITS :
-            for i in range(13):
-                self.cards.append(Card(i+2, suit))
+        if shuffleFlag:
+            for suit in self.SUITS :
+                for i in range(13):
+                    self.cards.append(Card(i+2, suit))
+            self.shuffle()
+        else:
+            # Parse deckSequence
+            # Each card will be in the form: "[<#|T|J|Q|K|A> <Sp|Cl|Di|He>]"
+            for cardString in deckSequence:
+                # Remove the brackets
+                cardString = cardString[1:-1]
+                valString, suitShort = cardString.split(" ")
+                val = 0
+                suit = ""
+                # Parse val
+                # If the TJQKA gets canned, JUST USE THE ELSE, it'll work on numbers
+                if valString == "T":
+                    val = 10
+                elif valString == "J":
+                    val = 11
+                elif valString == "Q":
+                    val = 12
+                elif valString == "K":
+                    val = 13
+                elif valString == "A":
+                    val = 14
+                else:
+                    val = int(valString)
+                
+                # Parse suit
+                if suitShort == "Sp":
+                    suit = "Spades"
+                elif suitShort == "Cl":
+                    suit = "Clubs"
+                elif suitShort == "Di":
+                    suit = "Diamonds"
+                elif suitShort == "He":
+                    suit = "Hearts"
+                self.cards.append(Card(val, suit))
+            # Reverse so that the cards are drawn in the order specified in the deckSequence
+            self.cards.reverse()
 
     def shuffle(self):
         random.shuffle(self.cards)

--- a/Engine/poker.py
+++ b/Engine/poker.py
@@ -23,7 +23,6 @@ class Poker:
     def runRound(self):
         # Define some variables
         deck = Deck()
-        deck.shuffle()
         players = self.players
         playersPassing = []
         playersFolding = []


### PR DESCRIPTION
Constructor now takes two additional optional arguments. If specified, the deckSequence will be parsed into the deck instead of the standard 52 cards, and no shuffling will be applied. The "deck.shuffle()" was removed from poker.py, as it is now redundant if shuffle=true, and unwanted if shuffle=false.

The constructor assumes that the deckSequence passed in will be an array of strings with the following format:
```"[<#|T|J|Q|K|A> <Sp|Cl|Di|He>]"```
- If this changes, PLEASE remember to update deck.py or it will not work.
- That being said, don't hesitate to change it, as it's probably easier to change the deck.py constructor than it is to change the entire testing structure format.

Fixes #17