### PR TITLE
Added functionality for OP_MAX action, Refactored Betting Ratios, and Removed Tie-Breaking

### DIFF
--- a/Engine/monte_carlo_agent.py
+++ b/Engine/monte_carlo_agent.py
@@ -141,6 +141,27 @@ class MonteCarloAgent(Agent):
                 validActions.remove(Action.LOW_BET)
                 validActions.remove(Action.MID_BET)
                 validActions.remove(Action.HIGH_BET)
+            # OP_MAX action handling
+            opponentIdx = (board.activePlayerIndex + 1) % board.players.__len__()
+            if self.players[int(opponentIdx)].chips == 0:
+                # Opponent is already all in
+                validActions.remove(Action.OP_MAX)
+                validActions.remove(Action.MIN_BET)
+                validActions.remove(Action.MID_BET)
+                validActions.remove(Action.HIGH_BET)
+            if board.players[int(opponentIdx)].chips + incomingBet >= board.players[int(board.activePlayerIndex)].chips:
+                # Not enough chips to overbet other player
+                validActions.remove(Action.OP_MAX)
+            else:
+                # These actions would now overbet the opponent max
+                validActions.remove(Action.ALL_IN)
+                opponentMax = board.players[int(opponentIdx)].chips
+                if incomingBet + board.players[board.activePlayerIndex].chips * 0.1 > opponentMax:
+                    validActions.remove(Action.LOW_BET)
+                if incomingBet + board.players[board.activePlayerIndex].chips * 0.4 > opponentMax:
+                    validActions.remove(Action.MID_BET)
+                if incomingBet + board.players[board.activePlayerIndex].chips * 0.7 > opponentMax:
+                    validActions.remove(Action.HIGH_BET)
             
             return validActions
 

--- a/Engine/monte_carlo_agent.py
+++ b/Engine/monte_carlo_agent.py
@@ -1,5 +1,5 @@
 from player import Player
-from player import Action
+from player import Action, BetRatio
 from agent import Agent
 from deck import Deck
 # Get the Board from Round with Round.Board(<constructor arguments>)
@@ -156,11 +156,11 @@ class MonteCarloAgent(Agent):
                 # These actions would now overbet the opponent max
                 validActions.remove(Action.ALL_IN)
                 opponentMax = board.players[int(opponentIdx)].chips
-                if incomingBet + board.players[board.activePlayerIndex].chips * 0.1 > opponentMax:
+                if incomingBet + board.players[board.activePlayerIndex].chips * BetRatio.LOW_BET > opponentMax:
                     validActions.remove(Action.LOW_BET)
-                if incomingBet + board.players[board.activePlayerIndex].chips * 0.4 > opponentMax:
+                if incomingBet + board.players[board.activePlayerIndex].chips * BetRatio.MID_BET > opponentMax:
                     validActions.remove(Action.MID_BET)
-                if incomingBet + board.players[board.activePlayerIndex].chips * 0.7 > opponentMax:
+                if incomingBet + board.players[board.activePlayerIndex].chips * BetRatio.HIGH_BET > opponentMax:
                     validActions.remove(Action.HIGH_BET)
             
             return validActions

--- a/Engine/player.py
+++ b/Engine/player.py
@@ -10,6 +10,7 @@ class Action(Enum):
     CALL = "call"
     CHECK = "check"
     FOLD = "fold"
+    OP_MAX = "op_max" # Short for "Opponent_Max"
 
 class Player(ABC):
 

--- a/Engine/player.py
+++ b/Engine/player.py
@@ -12,6 +12,11 @@ class Action(Enum):
     FOLD = "fold"
     OP_MAX = "op_max" # Short for "Opponent_Max"
 
+class BetRatio():
+    LOW_BET = 0.1
+    MID_BET = 0.4
+    HIGH_BET = 0.7
+
 class Player(ABC):
 
     def __init__(self, id, chips):

--- a/Engine/poker.py
+++ b/Engine/poker.py
@@ -19,8 +19,8 @@ class Poker:
 
     def __init__(self, players, startChips, minBet, shuffleFlag=True, deckSequences=None, supressOutput=False) -> None:
         self.players = []
-#         self.players.append(RealPlayer(1, startChips))
-#         self.players.append(MonteCarloAgent(2, startChips))
+        # self.players.append(RealPlayer(1, startChips))
+        # self.players.append(MonteCarloAgent(2, startChips))
         for i in range(players.__len__()):
             players[i].chips = startChips
             players[i].nextGame()
@@ -540,5 +540,5 @@ testGame = Poker([RealPlayer(1, 0), RealPlayer(2, 0)],startChips = 100, minBet =
 
 # testGame = Poker([RealPlayer(1, 0), RealPlayer(2, 0)],startChips = 100, minBet = 2, shuffleFlag=False, decksequences="../Testing/test_sequencesRound3.txt") #feed 4 decks, 2 for each game example
 
-# testGame.runGame()
+testGame.runGame()
 

--- a/Engine/realPlayer.py
+++ b/Engine/realPlayer.py
@@ -1,5 +1,5 @@
 from player import Player
-from player import Action
+from player import Action, BetRatio
 
 class RealPlayer(Player):
 
@@ -19,9 +19,9 @@ class RealPlayer(Player):
         # CALL = CHECK = Up to current bet
         # FOLD = drop out
         MIN_BET_STR = "" if Action.MIN_BET not in validActions else f"MIN_BET ({incomingBet} + {board.minBet} = {incomingBet + board.minBet}) (raise)"
-        LOW_BET_STR = "" if Action.LOW_BET not in validActions else f"LOW_BET ({incomingBet} + {self.chips * 0.1 if self.chips * 0.1 > board.minBet else board.minBet} = {incomingBet + self.chips * 0.1 if self.chips * 0.1 > board.minBet else board.minBet}) (raise)"
-        MID_BET_STR = "" if Action.MID_BET not in validActions else f"MID_BET ({incomingBet} + {self.chips * 0.4 if self.chips * 0.4 > board.minBet else board.minBet} = {incomingBet + self.chips * 0.4 if self.chips * 0.4 > board.minBet else board.minBet}) (raise)"
-        HIGH_BET_STR = "" if Action.HIGH_BET not in validActions else f"HIGH_BET ({incomingBet} + {self.chips * 0.7 if self.chips * 0.7 > board.minBet else board.minBet} = {incomingBet + self.chips * 0.7 if self.chips * 0.7 > board.minBet else board.minBet}) (raise)"
+        LOW_BET_STR = "" if Action.LOW_BET not in validActions else f"LOW_BET ({incomingBet} + {self.chips * BetRatio.LOW_BET if self.chips * BetRatio.LOW_BET > board.minBet else board.minBet} = {incomingBet + self.chips * BetRatio.LOW_BET if self.chips * BetRatio.LOW_BET > board.minBet else board.minBet}) (raise)"
+        MID_BET_STR = "" if Action.MID_BET not in validActions else f"MID_BET ({incomingBet} + {self.chips * BetRatio.MID_BET if self.chips * BetRatio.MID_BET > board.minBet else board.minBet} = {incomingBet + self.chips * BetRatio.MID_BET if self.chips * BetRatio.MID_BET > board.minBet else board.minBet}) (raise)"
+        HIGH_BET_STR = "" if Action.HIGH_BET not in validActions else f"HIGH_BET ({incomingBet} + {self.chips * BetRatio.HIGH_BET if self.chips * BetRatio.HIGH_BET > board.minBet else board.minBet} = {incomingBet + self.chips * BetRatio.HIGH_BET if self.chips * BetRatio.HIGH_BET > board.minBet else board.minBet}) (raise)"
         opponentMax = board.players[int((board.activePlayerIndex + 1) % board.players.__len__())].chips
         OP_MAX_STR = "" if Action.OP_MAX not in validActions else f"OP_MAX ({incomingBet} + {opponentMax if opponentMax > board.minBet else board.minBet} = {incomingBet + opponentMax if opponentMax > board.minBet else board.minBet}) (raise)"
         ALL_IN_STR = "" if Action.ALL_IN not in validActions else f"ALL_IN  ({self.chips})"

--- a/Engine/realPlayer.py
+++ b/Engine/realPlayer.py
@@ -22,6 +22,8 @@ class RealPlayer(Player):
         LOW_BET_STR = "" if Action.LOW_BET not in validActions else f"LOW_BET ({incomingBet} + {self.chips * 0.1 if self.chips * 0.1 > board.minBet else board.minBet} = {incomingBet + self.chips * 0.1 if self.chips * 0.1 > board.minBet else board.minBet}) (raise)"
         MID_BET_STR = "" if Action.MID_BET not in validActions else f"MID_BET ({incomingBet} + {self.chips * 0.4 if self.chips * 0.4 > board.minBet else board.minBet} = {incomingBet + self.chips * 0.4 if self.chips * 0.4 > board.minBet else board.minBet}) (raise)"
         HIGH_BET_STR = "" if Action.HIGH_BET not in validActions else f"HIGH_BET ({incomingBet} + {self.chips * 0.7 if self.chips * 0.7 > board.minBet else board.minBet} = {incomingBet + self.chips * 0.7 if self.chips * 0.7 > board.minBet else board.minBet}) (raise)"
+        opponentMax = board.players[int((board.activePlayerIndex + 1) % board.players.__len__())].chips
+        OP_MAX_STR = "" if Action.OP_MAX not in validActions else f"OP_MAX ({incomingBet} + {opponentMax if opponentMax > board.minBet else board.minBet} = {incomingBet + opponentMax if opponentMax > board.minBet else board.minBet}) (raise)"
         ALL_IN_STR = "" if Action.ALL_IN not in validActions else f"ALL_IN  ({self.chips})"
         CALL_STR = "" if Action.CALL not in validActions else f"CALL ({incomingBet}) (cannot perform when the incoming bet is 0)"
         CHECK_STR = "" if Action.CHECK not in validActions else f"CHECK (only if incoming bet is 0 and no players have bet or raised before you)"
@@ -32,6 +34,7 @@ class RealPlayer(Player):
             {LOW_BET_STR}
             {MID_BET_STR}
             {HIGH_BET_STR}
+            {OP_MAX_STR}
             {ALL_IN_STR}
             {CALL_STR}
             {CHECK_STR}
@@ -55,6 +58,8 @@ class RealPlayer(Player):
             action_enum = Action.MID_BET
         elif action == "HIGH_BET":
             action_enum = Action.HIGH_BET
+        elif action == "OP_MAX":
+            action_enum = Action.OP_MAX
         elif action == "ALL_IN":
             action_enum = Action.ALL_IN
         elif action == "CALL":

--- a/Engine/round.py
+++ b/Engine/round.py
@@ -1,6 +1,6 @@
 from realPlayer import RealPlayer
 from deck import Deck
-from realPlayer import Action
+from player import Action, BetRatio
 
 class Round:
     class Board:
@@ -82,11 +82,11 @@ class Round:
             # These actions would now overbet the opponent max
             validActions.remove(Action.ALL_IN)
             opponentMax = self.players[int(opponentIdx)].chips
-            if incomingBet + self.players[activePlayerIndex].chips * 0.1 > opponentMax:
+            if incomingBet + self.players[activePlayerIndex].chips * BetRatio.LOW_BET > opponentMax:
                 validActions.remove(Action.LOW_BET)
-            if incomingBet + self.players[activePlayerIndex].chips * 0.4 > opponentMax:
+            if incomingBet + self.players[activePlayerIndex].chips * BetRatio.MID_BET > opponentMax:
                 validActions.remove(Action.MID_BET)
-            if incomingBet + self.players[activePlayerIndex].chips * 0.7 > opponentMax:
+            if incomingBet + self.players[activePlayerIndex].chips * BetRatio.HIGH_BET > opponentMax:
                 validActions.remove(Action.HIGH_BET)
         
         return validActions
@@ -97,11 +97,11 @@ class Round:
         if action == Action.MIN_BET:
             playerBet = incomingBet + self.minBet
         elif action == Action.LOW_BET:
-            playerBet = incomingBet + self.players[activePlayerIndex].chips * 0.1 if self.players[activePlayerIndex].chips * 0.1 > self.minBet else self.minBet
+            playerBet = incomingBet + self.players[activePlayerIndex].chips * BetRatio.LOW_BET if self.players[activePlayerIndex].chips * BetRatio.LOW_BET > self.minBet else self.minBet
         elif action == Action.MID_BET:
-            playerBet = incomingBet + self.players[activePlayerIndex].chips * 0.4 if self.players[activePlayerIndex].chips * 0.4 > self.minBet else self.minBet
+            playerBet = incomingBet + self.players[activePlayerIndex].chips * BetRatio.MID_BET if self.players[activePlayerIndex].chips * BetRatio.MID_BET > self.minBet else self.minBet
         elif action == Action.HIGH_BET:
-            playerBet = incomingBet + self.players[activePlayerIndex].chips * 0.7 if self.players[activePlayerIndex].chips * 0.7 > self.minBet else self.minBet
+            playerBet = incomingBet + self.players[activePlayerIndex].chips * BetRatio.HIGH_BET if self.players[activePlayerIndex].chips * BetRatio.HIGH_BET > self.minBet else self.minBet
 
         # Update the stored player bet thus far
         self.board.playerBets[activePlayerIndex] += playerBet

--- a/Engine/round.py
+++ b/Engine/round.py
@@ -509,7 +509,8 @@ class Round:
         else:
             score = 100 + HIGH_CARD
 
-        # Ties will be broken by whichever player has the higher cards in hand
+        # OUTDATED::::Ties will be broken by whichever player has the higher cards in hand
+        # NOTE: Ties will result in split pot now
         return score
 
         
@@ -770,45 +771,49 @@ class Round:
                 for i in winningIndex:
                     print(f"Player {self.players[i].id}")
             
-            # Identify tie-break scores
-            tieScores = []
-            for i in range(self.players.__len__()):
-                # If not a winner, no tiebreak score
-                if i not in winningIndex:
-                    tieScores.append(0)
-                # If a winner, calculate tie-break score
-                else:
-                    temp = self.players[i].cardsInHand
-                    temp.sort(key=lambda x: x.value, reverse = True)
-                    # tie-break score = high card value * 10 + low card value
-                    tieScores.append(temp[0].value * 10 + temp[1].value)
+            # NOTE: The commented code from here until the other note is the tie-breaker functionality.
+            #       It is not being used due to ties resulting in split pots being normal poker rules.
+            # # Identify tie-break scores
+            # tieScores = []
+            # for i in range(self.players.__len__()):
+            #     # If not a winner, no tiebreak score
+            #     if i not in winningIndex:
+            #         tieScores.append(0)
+            #     # If a winner, calculate tie-break score
+            #     else:
+            #         temp = self.players[i].cardsInHand
+            #         temp.sort(key=lambda x: x.value, reverse = True)
+            #         # tie-break score = high card value * 10 + low card value
+            #         tieScores.append(temp[0].value * 10 + temp[1].value)
             
-            # Display information about tie-breaker hands
-            if not self.supressOuptut:
-                print("Tie Breaker Hands:")
-                for i in winningIndex:
-                    print(f"Player {self.players[i].id} hand: "+ ", ".join(str(card) for card in self.players[i].cardsInHand))
+            # # Display information about tie-breaker hands
+            # if not self.supressOuptut:
+            #     print("Tie Breaker Hands:")
+            #     for i in winningIndex:
+            #         print(f"Player {self.players[i].id} hand: "+ ", ".join(str(card) for card in self.players[i].cardsInHand))
 
-            # Find winners
-            tiebreaker = -1
-            tieWinningIndex = []
-            for i in winningIndex:
-                if tieScores[i] > tiebreaker:
-                    tiebreaker = tieScores[i]
-                    tieWinningIndex = [i]
-                # There can be multiple Players with equal strength hands
-                elif tieScores[i] == tiebreaker:
-                    tieWinningIndex.append(i)
+            # # Find winners
+            # tiebreaker = -1
+            # tieWinningIndex = []
+            # for i in winningIndex:
+            #     if tieScores[i] > tiebreaker:
+            #         tiebreaker = tieScores[i]
+            #         tieWinningIndex = [i]
+            #     # There can be multiple Players with equal strength hands
+            #     elif tieScores[i] == tiebreaker:
+            #         tieWinningIndex.append(i)
 
-            # Display information about who won the tie-break
-            winningIndex = tieWinningIndex
-            if not self.supressOuptut:
-                if winningIndex.__len__() == 1:
-                    print(f"The tiebreak winner is: Player {winningIndex[0] + 1}")
-                else:
-                    print(f"The tiebreak winners are:")
-                    for i in winningIndex:
-                        print(f"Player {self.players[i].id}")
+            # # Display information about who won the tie-break
+            # winningIndex = tieWinningIndex
+            # if not self.supressOuptut:
+            #     if winningIndex.__len__() == 1:
+            #         print(f"The tiebreak winner is: Player {winningIndex[0] + 1}")
+            #     else:
+            #         print(f"The tiebreak winners are:")
+            #         for i in winningIndex:
+            #             print(f"Player {self.players[i].id}")
+            # NOTE: End of tie-break functionality
+            
         else: 
             # Display information about who won the pot
             if not self.supressOuptut:


### PR DESCRIPTION
OP_MAX Functionality #71:
- Added to player (action storage)
- Added to real player (enabling real players to choose it) Added to monte_carlo (enabling monte carlo to choose it)
- Added to round (enabling the functionality itself) Currently, if you have more chips than your opponent's remaining chips + the incoming bet, you get the OP_MAX option. If any bet option besides MIN_BET would over bet the opponent's max, it is removed as a choice. Also, if the opponent is all in, the player's options are limited to CALL, ALL_IN, and FOLD, since anything else would be redundant/pointless.

Betting Ratio functionality #77:
- Reduced the low, mid, and high bet ratios down to a single class located in the player.py file named BetRatio.
- Replaced every instance of the hard-coded values with a reference to the class, so that it can all be changed from one spot if necessary.

Tie-Breaker Removal #70:
- Now when two players have hands that score the same, they split the pot. There is no tie-break round.

